### PR TITLE
Add support for 'Literal, List, Any, Optional, Union' and List[BaseModels]

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -479,6 +479,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "nbclient"
 version = "0.5.9"
 description = "A client library for executing notebooks. Formerly nbconvert's ExecutePreprocessor."
@@ -987,6 +995,18 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "typing-inspect"
+version = "0.7.1"
+description = "Runtime inspection utilities for typing module."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+mypy-extensions = ">=0.3.0"
+typing-extensions = ">=3.7.4"
+
+[[package]]
 name = "wcwidth"
 version = "0.2.5"
 description = "Measures the displayed width of unicode strings in a terminal"
@@ -1028,7 +1048,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "9ea165e935ae0050c40583367e9cbf909bab7e616e5a6e0cab7ef9850b34089e"
+content-hash = "d6ab64163a97ddc8cbaf9e38b63d513b9643ab649ac7be6417cd7c2da15582c3"
 
 [metadata.files]
 appnope = [
@@ -1332,6 +1352,10 @@ mistune = [
     {file = "mistune-0.8.4-py2.py3-none-any.whl", hash = "sha256:88a1051873018da288eee8538d476dffe1262495144b33ecb586c4ab266bb8d4"},
     {file = "mistune-0.8.4.tar.gz", hash = "sha256:59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e"},
 ]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
 nbclient = [
     {file = "nbclient-0.5.9-py3-none-any.whl", hash = "sha256:8a307be4129cce5f70eb83a57c3edbe45656623c31de54e38bb6fdfbadc428b3"},
     {file = "nbclient-0.5.9.tar.gz", hash = "sha256:99e46ddafacd0b861293bf246fed8540a184adfa3aa7d641f89031ec070701e0"},
@@ -1634,6 +1658,11 @@ traitlets = [
 typing-extensions = [
     {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
     {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
+]
+typing-inspect = [
+    {file = "typing_inspect-0.7.1-py2-none-any.whl", hash = "sha256:b1f56c0783ef0f25fb064a01be6e5407e54cf4a4bf4f3ba3fe51e0bd6dcea9e5"},
+    {file = "typing_inspect-0.7.1-py3-none-any.whl", hash = "sha256:3cd7d4563e997719a710a3bfe7ffb544c6b72069b6812a02e9b414a8fa3aaa6b"},
+    {file = "typing_inspect-0.7.1.tar.gz", hash = "sha256:047d4097d9b17f46531bf6f014356111a1b6fb821a24fe7ac909853ca2a782aa"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/pydantic_sqlite/_misc.py
+++ b/pydantic_sqlite/_misc.py
@@ -1,5 +1,4 @@
 import os
-from typing import List
 
 
 def remove_file(name):
@@ -15,12 +14,6 @@ def uniquify(path):
         counter += 1
 
     return path
-
-def isiterable(obj):
-    if isinstance(obj, List):
-        return True
-    else:
-        return False
 
 def iterable_in_type_repr(type_repr):
     if 'List' in type_repr: 

--- a/pydantic_sqlite/_misc.py
+++ b/pydantic_sqlite/_misc.py
@@ -1,4 +1,5 @@
 import os
+from typing import List
 
 
 def remove_file(name):
@@ -14,3 +15,15 @@ def uniquify(path):
         counter += 1
 
     return path
+
+def isiterable(obj):
+    if isinstance(obj, List):
+        return True
+    else:
+        return False
+
+def iterable_in_type_repr(type_repr):
+    if 'List' in type_repr: 
+        return True
+    else:
+        return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ include = [
 python = "^3.8"
 pydantic = "^1.8.2"
 sqlite-utils = "^3.19"
+typing-inspect = "^0.7.1"
 
 [tool.poetry.dev-dependencies]
 isort = "^5.10.1"

--- a/tests/test_fields_basic.py
+++ b/tests/test_fields_basic.py
@@ -1,4 +1,5 @@
 from random import choice
+from typing import List
 from uuid import uuid4
 
 from hypothesis import given
@@ -18,6 +19,7 @@ class Example(BaseModel):
     ex_int: int
     ex_float: float
     ex_bool: bool
+    ex_list: List[str]
 
 @st.composite
 def example_values(draw):
@@ -26,7 +28,8 @@ def example_values(draw):
         ex_str=draw(st.text()),
         ex_int=draw(st.integers(min_value=SQLITE_INTEGERS_MIN, max_value=SQLITE_INTEGERS_MAX)),
         ex_float=draw(st.floats(min_value=SQLITE_FLOAT_MIN, max_value=SQLITE_FLOAT_MAX)),
-        ex_bool=draw(st.booleans())
+        ex_bool=draw(st.booleans()),
+        ex_list=draw(st.lists(st.text())),
     )
 
 

--- a/tests/test_fields_extends.py
+++ b/tests/test_fields_extends.py
@@ -1,5 +1,5 @@
 from random import choice
-from typing import Literal
+from typing import Any, List, Literal
 from uuid import uuid4
 
 from hypothesis import given
@@ -12,12 +12,14 @@ VALID_LITERALS = ['hello', 'hi', 'hey']
 class Example(BaseModel):
     uuid: str
     ex_Literal: Literal['hello', 'hi', 'hey']
+    ex_list_any: List[Any]
 
 @st.composite
 def example_values(draw):
     return dict(
         uuid=uuid4().__str__(),
-        ex_Literal=draw(st.sampled_from(VALID_LITERALS))
+        ex_Literal=draw(st.sampled_from(VALID_LITERALS)),
+        ex_list_any=draw(st.lists(st.text())),
     )
 
 @given(example_values())

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -1,3 +1,4 @@
+from typing import List
 from uuid import uuid4
 
 from pydantic import BaseModel, validator
@@ -16,6 +17,9 @@ class Baz(BaseModel):
     uuid: str
     bar: Bar
 
+class FooList(BaseModel):
+    uuid: str
+    testcase: List[Foo]
 
 class Hello(BaseModel):
     name: str
@@ -69,6 +73,20 @@ def test_nested_BaseModels_Level_2():
 
     db.add('Baz', baz, foreign_tables={"bar": "Bar"})
     assert db.value_in_table('Baz', baz)
+
+def test_nested_BaseModels_in_Typing_List():
+    db = DataBase()
+
+    foo1 = Foo(uuid=str(uuid4()), name="unitest")
+    foo2 = Foo(uuid=str(uuid4()), name="unitest")
+    ex = FooList(uuid=str(uuid4()), testcase=[foo1, foo2])
+
+    db.add('Foo', foo1)
+    db.add('Foo', foo2)
+    db.add('FooList', ex, foreign_tables={'testcase': 'Foo'})
+
+    assert db.value_in_table('FooList', ex)
+    assert [foo1, foo2] == db.value_from_table('FooList', ex.uuid).testcase
 
 def test_skip_nested():
     db = DataBase()


### PR DESCRIPTION
* add support for fields of type: `Literal, List, Any, Optional, Union`. 
* BaseModels that are in a nested list of other BaseModels are supported now:

```python
class Foo(BaseModel):
    uuid: str
    value: Any

class FooList(BaseModel):
    uuid: str
    foos: List[Foo]
```
