### PR TITLE
add support for special insert in a List of nested BaseModels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Change Log
+
+## [0.2.1] - 2022-01-10
+### Fixed
+* If an object that is to be added to a table, which contains as a attribute a list with further BaseModels that have a special insert, an error occurred. This has now been fixed  by @Phil997 in #7
+
  
 ## [0.2.0] - 2022-01-10
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydantic_sqlite"
-version = "0.2.0"
+version = "0.2.1"
 description = "Simple package for storing pydantic BaseModels in an in-memory SQLite database."
 authors = ["Your Name <you@example.com>"]
 license = "MIT"

--- a/tests/test_fields_basic.py
+++ b/tests/test_fields_basic.py
@@ -2,10 +2,13 @@ from random import choice
 from typing import List
 from uuid import uuid4
 
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis import strategies as st
 from pydantic import BaseModel
 from pydantic_sqlite import DataBase
+
+settings.register_profile("pydantic-sqlite", deadline=500)
+settings.load_profile("pydantic-sqlite")
 
 SQLITE_INTEGERS_MAX = 2**63-1
 SQLITE_INTEGERS_MIN = -2**63


### PR DESCRIPTION
If an object that is to be added to a table, which contains as a attribute a list with further BaseModels that have a special insert, an error occurred. This has now been fixed: 
Example see here:


```python

class Example(BaseModel):
    name: str

    class SQConfig:
        special_insert: bool = True

        def convert(obj):
            return f"_{obj.name}"

class Example3(BaseModel):
    uuid: str
    data: List[Example]

    @validator('data', pre=True)
    def validate(cls, v):
        ...

```