### PR TITLE
persistent db

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+# - repo: https://github.com/ambv/black
+#   rev: 24.4.2
+#   hooks:
+#   - id: black
+-   repo: https://github.com/PyCQA/flake8
+    rev: 7.0.0
+    hooks:
+    -   id: flake8
+# - repo: https://github.com/timothycrosley/isort
+#   rev: '5.13.2'
+#   hooks:
+#   - id: isort
+#     additional_dependencies:
+#       - toml

--- a/pydantic_sqlite/_core.py
+++ b/pydantic_sqlite/_core.py
@@ -195,7 +195,7 @@ class DataBase():
         """
 
         if self.filename == ':memory:':
-            logging.warning(f"database is persistent, already stored in a file: {self._db.conn.execute('PRAGMA database_list').fetchone()[2]}")
+            logging.warning(f"database is persistent, already stored in a file: {self.filename}")
             return
         
         if not filename.endswith(".db"):

--- a/pydantic_sqlite/_core.py
+++ b/pydantic_sqlite/_core.py
@@ -219,7 +219,7 @@ class DataBase:
             If the database is persistent, the function will do nothing and return None.
         """
 
-        if self.filename == ":memory:":
+        if self.filename != ":memory:":
             logging.warning(
                 f"database is persistent, already stored in a file: {self.filename}"
             )

--- a/pydantic_sqlite/_core.py
+++ b/pydantic_sqlite/_core.py
@@ -177,12 +177,15 @@ class DataBase():
                 pks=json.loads(model['pks']))
 
     @property
-    def is_in_memory(self) -> bool:
+    def filename(self) -> str:
+        """returns the filename of the database.
+        If the database is in-memory, the function will return `:memory:`
+        """
         db_filename = self._db.conn.execute("PRAGMA database_list").fetchone()[2]
-        if db_filename == '' or db_filename == ':memory:':
-            return True
+        if db_filename in {'', ':memory:'}:
+            return ':memory:'
         else:
-            return False
+            return db_filename
 
     def save(self, filename: str) -> None:
         """saves all values from the in-memory database to a file
@@ -191,7 +194,7 @@ class DataBase():
             If the database is persistent, the function will do nothing and return None.
         """
 
-        if not self.is_in_memory:
+        if self.filename == ':memory:':
             logging.warning(f"database is persistent, already stored in a file: {self._db.conn.execute('PRAGMA database_list').fetchone()[2]}")
             return
         

--- a/tests/test_save_and_load.py
+++ b/tests/test_save_and_load.py
@@ -167,3 +167,6 @@ def test_persistent_db_save(persistent_db):
         )
         # Verify no file operations were performed
         assert not os.path.exists("_backup.db")
+    
+    # Close the database connection before the test ends
+    persistent_db._db.conn.close()

--- a/tests/test_save_and_load.py
+++ b/tests/test_save_and_load.py
@@ -37,6 +37,7 @@ def db():
     assert len(list(db(TEST_TABLE_NAME))) == LENGTH
     return db
 
+
 @pytest.fixture()
 def persistent_db(dir):
     db = DataBase(filename_or_conn=(dir + TEST_DB_NAME))
@@ -45,6 +46,7 @@ def persistent_db(dir):
         db.add(TEST_TABLE_NAME, foo)
     assert len(list(db(TEST_TABLE_NAME))) == LENGTH
     return db
+
 
 def test_save_with_file_ending(dir, db):
     db.save(dir + "hello.db")
@@ -64,7 +66,7 @@ def test_save_override_existing_db(dir, db):
 
     for _ in range(LENGTH):
         foo = Foo(uuid=str(uuid4()), name="unitest")
-        db.add('Foo2', foo)
+        db.add("Foo2", foo)
     assert len(db._db.table_names()) == 3
 
     db.save(dir + TEST_DB_NAME)
@@ -127,7 +129,6 @@ def test_handler_save_DataBase(dir):
 def test_handler_load(dir, db):
     db.save(dir + TEST_DB_NAME)
     with DB_Handler(dir + TEST_DB_NAME) as testdb:
-
         for foo in testdb(TEST_TABLE_NAME):
             assert issubclass(foo.__class__, BaseModel)
             assert isinstance(foo, Foo)
@@ -154,12 +155,13 @@ def test_handler_save_multiple_ExceptionDB_on_exception(dir, db):
             raise DummyExeption()
     assert f"{TEST_DB_NAME[:-3]}_crash(1).db" in os.listdir(dir)
 
+
 def test_persistent_db_save(persistent_db):
     filename = persistent_db._db.conn.execute("PRAGMA database_list").fetchone()[2]
-    
-    with mock.patch('logging.warning') as mock_warning:
+
+    with mock.patch("logging.warning") as mock_warning:
         persistent_db.save(TEST_DB_NAME)
-    
+
         mock_warning.assert_called_once_with(
             f"database is persistent, already stored in a file: {filename}"
         )

--- a/tests/test_save_and_load.py
+++ b/tests/test_save_and_load.py
@@ -167,6 +167,6 @@ def test_persistent_db_save(persistent_db):
         )
         # Verify no file operations were performed
         assert not os.path.exists("_backup.db")
-    
+
     # Close the database connection before the test ends
     persistent_db._db.conn.close()


### PR DESCRIPTION
Persistent (file-based) database (resolves #22)

Changes
1. `DataBase` object now allows `filename_or_conn` optional parameter on initialisation (same naming as in `sqlite_utils`). If param is none, will initialise with `memory=True`, else will use path/connection to initialize.
2. It also now passes kwargs to `_Database`
Note: if you think filebase db is such a niche use case, I can switch to simply passing kwargs (including filename_or_conn) to database object
3. `DataBase` now has `filename` property that returns path to file as string, or `:memory:` if in-memory
4. `DataBase.save` now will do nothing (but will log warning) if database is persistent

