### PR TITLE
FeatureFailSafeDataBase update

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ print(next(db("CarRegistrations")))
 
 ```
 
-### DB_Handler
-The `DB_Handler` serves as a context manager wrapper for the `DataBase`. The database returned by the context manager functions identically to those in previous examples.
+### FailSafeDataBase
+The `FailSafeDataBase` serves as a context manager wrapper for the `DataBase`. The database returned by the context manager functions identically to those in previous examples.
 
 However, the handler offers an added benefit: in case of an exception, it automatically saves a database snapshot with the latest values as `<<dbname>_snapshot.db` (by default). If such a file already exists, the filename is iteratively incremented (e.g., `<<dbname>_snapshot(1).db`).
 
@@ -205,14 +205,14 @@ For instance, running this example generates two files: `humans.db` and `humans_
 ```python
 from uuid import uuid4
 from pydantic import BaseModel
-from pydantic_sqlite import DB_Handler
+from pydantic_sqlite import FailSafeDataBase
 
 class Person(BaseModel):
     uuid: str
     name: str
     age: int
 
-with DB_Handler("humans", snapshot_suffix="_snapshot.db") as db:
+with FailSafeDataBase("humans", snapshot_suffix="_snapshot.db") as db:
     test1 = Person(uuid=str(uuid4()), name="Bob", age=12)
     db.add("Test", test1)
     for x in db("Test"):

--- a/pydantic_sqlite/__init__.py
+++ b/pydantic_sqlite/__init__.py
@@ -1,7 +1,7 @@
 from ._core import DataBase
-from ._handler import DB_Handler
+from ._wrapper import FailSafeDataBase
 
 __all__ = [
-    "DB_Handler",
+    "FailSafeDataBase",
     "DataBase"
 ]

--- a/pydantic_sqlite/_handler.py
+++ b/pydantic_sqlite/_handler.py
@@ -20,7 +20,7 @@ class DB_Handler:
     _ctx: Optional[_GeneratorContextManager]
     snapshot_suffix: str
 
-    def __init__(self, dbname: str, snapshot_suffix: str = "_snapshot.db") -> None:
+    def __init__(self, dbname: str, snapshot_suffix: str = "_snapshot.db", **kwargs) -> None:
         """
         Initialize the DB_Handler with the given database name and snapshot suffix.
         Ensures the database filename ends with '.db'.
@@ -28,12 +28,14 @@ class DB_Handler:
         Args:
             dbname (str): The name of the database file (with or without '.db' extension).
             snapshot_suffix (str): The suffix to use for snapshot files (default: '_snapshot.db').
+            **kwargs: Additional keyword arguments to pass to the DataBase constructor.
         """
         self._ctx = None
         if not dbname.endswith(".db"):
             dbname += ".db"
         self.dbname = dbname
         self.snapshot_suffix = snapshot_suffix
+        self._db_kwargs = kwargs
 
     def __enter__(self) -> DataBase:
         """
@@ -75,7 +77,7 @@ class DB_Handler:
             DataBase: The database instance for use within the context.
         """
         try:
-            self.db = DataBase()
+            self.db = DataBase(**self._db_kwargs)
             if os.path.isfile(self.dbname):
                 self.db.load(self.dbname)
             yield self.db

--- a/pydantic_sqlite/_wrapper.py
+++ b/pydantic_sqlite/_wrapper.py
@@ -6,11 +6,11 @@ from ._core import DataBase
 from ._misc import get_unique_filename
 
 
-class DB_Handler:
+class FailSafeDataBase:
     """
     A context manager wrapper for the DataBase class that provides automatic db snapshotting on an exception.
 
-    When used as a context manager, DB_Handler returns a DataBase instance. If an exception occurs
+    When used as a context manager, FailSafeDataBase returns a DataBase instance. If an exception occurs
     within the context, it saves a snapshot of the database to a file named '<dbname>_snapshot.db' by default.
     If such a file already exists, the filename is incremented (e.g., '<dbname>_snapshot(1).db').
     The snapshot suffix can be configured via the constructor.
@@ -22,7 +22,7 @@ class DB_Handler:
 
     def __init__(self, dbname: str, snapshot_suffix: str = "_snapshot.db", **kwargs) -> None:
         """
-        Initialize the DB_Handler with the given database name and snapshot suffix.
+        Initialize the FailSafeDataBase with the given database name and snapshot suffix.
         Ensures the database filename ends with '.db'.
 
         Args:
@@ -46,7 +46,7 @@ class DB_Handler:
             DataBase: The database instance for use within the context.
         """
         if self._ctx is not None:
-            raise RuntimeError('DB_Handler is not reentrant')
+            raise RuntimeError('FailSafeDataBase is not reentrant')
         self._ctx = self._contextmanager()
         return self._ctx.__enter__()
 

--- a/pydantic_sqlite/_wrapper.py
+++ b/pydantic_sqlite/_wrapper.py
@@ -8,12 +8,22 @@ from ._misc import get_unique_filename
 
 class FailSafeDataBase:
     """
-    A context manager wrapper for the DataBase class that provides automatic db snapshotting on an exception.
+    Context manager for the DataBase class that automatically creates a database snapshot if
+    an unexpected exception occurs.
 
     When used as a context manager, FailSafeDataBase returns a DataBase instance. If an exception occurs
     within the context, it saves a snapshot of the database to a file named '<dbname>_snapshot.db' by default.
     If such a file already exists, the filename is incremented (e.g., '<dbname>_snapshot(1).db').
     The snapshot suffix can be configured via the constructor.
+
+    This class is designed to be fail-safe: if an error or exception interrupts database operations,
+    a backup snapshot is automatically created to prevent data loss.
+
+    Attributes:
+        dbname (str): The name of the database file.
+        db (DataBase): The database instance managed by this context manager.
+        _ctx (Optional[_GeneratorContextManager]): Internal context manager state.
+        snapshot_suffix (str): Suffix for snapshot files (default: '_snapshot.db').
     """
     dbname: str
     db: DataBase
@@ -39,8 +49,8 @@ class FailSafeDataBase:
 
     def __enter__(self) -> DataBase:
         """
-        Enters the context manager, returning a DataBase instance.
-        Raises an error if the handler is re-entered.
+        Enter the context manager, returning a DataBase instance.
+        Raises an error if the manager is re-entered.
 
         Returns:
             DataBase: The database instance for use within the context.
@@ -52,7 +62,7 @@ class FailSafeDataBase:
 
     def __exit__(self, exc_type: Optional[type], exc: Optional[BaseException], tb: Optional[Any]) -> Optional[bool]:
         """
-        Exits the context manager. If an exception occurred, saves a snapshot of the database.
+        Exit the context manager. If an exception occurred, automatically saves a snapshot of the database.
 
         Args:
             exc_type (Optional[type]): The exception type, if any.

--- a/tests/test_db_handler.py
+++ b/tests/test_db_handler.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from unittest import mock
 from uuid import uuid4
 
 import pytest
@@ -23,6 +24,24 @@ def test_context_manager():
         with pytest.raises(RuntimeError):
             with handler:
                 ...  # re-entering the context manager should raise an error
+
+
+def test_pass_kwargs(tmp_path: Path):
+    with mock.patch("pydantic_sqlite._core._Database") as mocked_sqlite_database:
+        with DB_Handler("mytest"):
+            mocked_sqlite_database.assert_called_once_with(memory=True)
+
+    with mock.patch("pydantic_sqlite._core._Database") as mocked_sqlite_database:
+        with DB_Handler("mytest", snapshot_suffix="_snapshot.db"):
+            mocked_sqlite_database.assert_called_once_with(memory=True)
+
+    with mock.patch("pydantic_sqlite._core._Database") as mocked_sqlite_database:
+        with DB_Handler("mytest", filename_or_conn=str(tmp_path / TEST_DB_NAME)):
+            mocked_sqlite_database.assert_called_once_with(str(tmp_path / TEST_DB_NAME))
+
+    with mock.patch("pydantic_sqlite._core._Database") as mocked_sqlite_database:
+        with DB_Handler("mytest", filename_or_conn=str(tmp_path / TEST_DB_NAME), strict=True):
+            mocked_sqlite_database.assert_called_once_with(str(tmp_path / TEST_DB_NAME), strict=True)
 
 
 def test_save_DataBase(tmp_path: Path):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 import pytest
 from pydantic import BaseModel
 
-from pydantic_sqlite import DataBase, DB_Handler
+from pydantic_sqlite import DataBase, FailSafeDataBase
 
 from ._helper import LENGTH, TEST_DB_NAME, TEST_TABLE_NAME, Person
 
@@ -16,10 +16,10 @@ class DummyExeption(Exception):
 
 
 def test_context_manager():
-    with DB_Handler("mytest") as db:
+    with FailSafeDataBase("mytest") as db:
         assert isinstance(db, DataBase)
 
-    handler = DB_Handler("mytest")
+    handler = FailSafeDataBase("mytest")
     with handler:
         with pytest.raises(RuntimeError):
             with handler:
@@ -28,24 +28,24 @@ def test_context_manager():
 
 def test_pass_kwargs(tmp_path: Path):
     with mock.patch("pydantic_sqlite._core._Database") as mocked_sqlite_database:
-        with DB_Handler("mytest"):
+        with FailSafeDataBase("mytest"):
             mocked_sqlite_database.assert_called_once_with(memory=True)
 
     with mock.patch("pydantic_sqlite._core._Database") as mocked_sqlite_database:
-        with DB_Handler("mytest", snapshot_suffix="_snapshot.db"):
+        with FailSafeDataBase("mytest", snapshot_suffix="_snapshot.db"):
             mocked_sqlite_database.assert_called_once_with(memory=True)
 
     with mock.patch("pydantic_sqlite._core._Database") as mocked_sqlite_database:
-        with DB_Handler("mytest", filename_or_conn=str(tmp_path / TEST_DB_NAME)):
+        with FailSafeDataBase("mytest", filename_or_conn=str(tmp_path / TEST_DB_NAME)):
             mocked_sqlite_database.assert_called_once_with(str(tmp_path / TEST_DB_NAME))
 
     with mock.patch("pydantic_sqlite._core._Database") as mocked_sqlite_database:
-        with DB_Handler("mytest", filename_or_conn=str(tmp_path / TEST_DB_NAME), strict=True):
+        with FailSafeDataBase("mytest", filename_or_conn=str(tmp_path / TEST_DB_NAME), strict=True):
             mocked_sqlite_database.assert_called_once_with(str(tmp_path / TEST_DB_NAME), strict=True)
 
 
 def test_save_DataBase(tmp_path: Path):
-    with DB_Handler(str(tmp_path / "mytest"), snapshot_suffix="_snapshot.db") as db:
+    with FailSafeDataBase(str(tmp_path / "mytest"), snapshot_suffix="_snapshot.db") as db:
         for _ in range(LENGTH):
             person = Person(uuid=str(uuid4()), name="unitest")
             db.add(TEST_TABLE_NAME, person)
@@ -56,7 +56,7 @@ def test_save_DataBase(tmp_path: Path):
 
 def test_load(tmp_path: Path, sample_db: DataBase):
     sample_db.save(str(tmp_path / TEST_DB_NAME))
-    with DB_Handler(dbname=str(tmp_path / TEST_DB_NAME), snapshot_suffix="_snapshot.db") as testdb:
+    with FailSafeDataBase(dbname=str(tmp_path / TEST_DB_NAME), snapshot_suffix="_snapshot.db") as testdb:
         for person in testdb(TEST_TABLE_NAME):
             assert issubclass(person.__class__, BaseModel)
             assert isinstance(person, Person)
@@ -65,10 +65,10 @@ def test_load(tmp_path: Path, sample_db: DataBase):
 def test_save_snapshot_on_exception(tmp_path: Path, sample_db: DataBase):
     sample_db.save(str(tmp_path / TEST_DB_NAME))
     with pytest.raises(KeyError):
-        with DB_Handler(str(tmp_path / TEST_DB_NAME), snapshot_suffix="_snapshot.db") as _:
+        with FailSafeDataBase(str(tmp_path / TEST_DB_NAME), snapshot_suffix="_snapshot.db") as _:
             raise KeyError()
     assert f"{TEST_DB_NAME[:-3]}_snapshot.db" in os.listdir(tmp_path)
     with pytest.raises(DummyExeption):
-        with DB_Handler(str(tmp_path / TEST_DB_NAME), snapshot_suffix="_snapshot.db") as _:
+        with FailSafeDataBase(str(tmp_path / TEST_DB_NAME), snapshot_suffix="_snapshot.db") as _:
             raise DummyExeption()
     assert f"{TEST_DB_NAME[:-3]}_snapshot(1).db" in os.listdir(tmp_path)


### PR DESCRIPTION
### Breaking Changes:
* Rename `DB_Handler` to `FailSafeDataBase`

### Features/Fixes:
* Pass `**kwargs` from `FailSafeDataBase.__init__` to the DataBase constructor

### Misc:
* Extend docstrings for FailSafeDataBase
* Some Refactoring

This PR is the second part of overhauling the DataBase Wrapper, the first one is #26 